### PR TITLE
Enable spnego-demo.war to work with EAP 7 or WildFly 10.x

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -31,6 +31,10 @@
 		</auth-constraint>
 	</security-constraint>
 
+	<login-config>
+		<auth-method>SPNEGO</auth-method>
+	</login-config>
+
 	<security-role>
 		<role-name>Admin</role-name>
 	</security-role>


### PR DESCRIPTION
Undertow will still output a warning about valves (see #2) but this way we keep compatibility with JBoss EAP 6.
